### PR TITLE
Циклические ссылки

### DIFF
--- a/postgres/setup.sql
+++ b/postgres/setup.sql
@@ -13,9 +13,9 @@ CREATE TABLE Worker (
     head_id integer REFERENCES Worker
 );
 
-
--- Источник: https://postgrespro.ru/docs/postgresql/9.6/plpgsql-trigger
 CREATE OR REPLACE FUNCTION check_worker_head() RETURNS TRIGGER AS $worker_head$
+    DECLARE
+        cur_row Worker%ROWTYPE;
     BEGIN
         IF NEW.head_id IS NULL THEN
             RETURN NEW;
@@ -26,13 +26,40 @@ CREATE OR REPLACE FUNCTION check_worker_head() RETURNS TRIGGER AS $worker_head$
         IF (SELECT org_id FROM Worker WHERE id = NEW.head_id LIMIT 1) != NEW.org_id THEN
             RAISE EXCEPTION 'org_id in worker and head worker must be equal';
         END IF;
+        IF TG_OP = 'INSERT' THEN
+            RETURN NEW;
+        END IF;
+        cur_row := NEW;
+        LOOP
+            EXIT WHEN cur_row.head_id IS NULL;
+            IF cur_row.head_id = NEW.id THEN
+                RAISE EXCEPTION 'new head_id value caused a loop';
+            END IF;
+            SELECT * INTO cur_row FROM Worker WHERE id = cur_row.head_id;
+        END LOOP;
         RETURN NEW;
     END;
 $worker_head$ LANGUAGE plpgsql;
 CREATE TRIGGER worker_head BEFORE INSERT OR UPDATE ON Worker
      FOR EACH ROW EXECUTE PROCEDURE check_worker_head();
 
-
-
-
-    
+CREATE OR REPLACE FUNCTION check_org_head() RETURNS TRIGGER AS $org_head$
+    DECLARE
+        cur_row Organization%ROWTYPE;
+    BEGIN
+        IF NEW.head_org_id IS NULL THEN
+            RETURN NEW;
+        END IF;
+        cur_row := NEW;
+        LOOP
+            EXIT WHEN cur_row.head_org_id IS NULL;
+            IF cur_row.head_org_id = NEW.id THEN
+                RAISE EXCEPTION 'new head_org_id value caused a loop';
+            END IF;
+            SELECT * INTO cur_row FROM Organization WHERE id = cur_row.head_org_id;
+        END LOOP;
+        RETURN NEW;
+    END;
+$org_head$ LANGUAGE plpgsql;
+CREATE TRIGGER org_head BEFORE UPDATE ON Organization
+     FOR EACH ROW EXECUTE PROCEDURE check_org_head();

--- a/postgres/tests/org_test.sql
+++ b/postgres/tests/org_test.sql
@@ -3,7 +3,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap;
 \set ON_ERROR_STOP true
 BEGIN;
 
-SELECT plan(7);
+SELECT plan(8);
 
 PREPARE org_insert AS INSERT INTO Organization VALUES
     (1, 'headOrg1', NULL),
@@ -12,6 +12,12 @@ PREPARE org_insert AS INSERT INTO Organization VALUES
     (4, 'Org_1_2', 1);
 SELECT lives_ok(
     'org_insert'
+);
+
+PREPARE org_update_self_update AS UPDATE Organization SET head_org_id = 3 WHERE id = 1;
+
+SELECT throws_ok(
+    'org_update_self_update'
 );
 
 PREPARE del_not_head_org AS DELETE FROM Organization WHERE id = 3;

--- a/postgres/tests/org_test.sql
+++ b/postgres/tests/org_test.sql
@@ -3,7 +3,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap;
 \set ON_ERROR_STOP true
 BEGIN;
 
-SELECT plan(8);
+SELECT plan(9);
 
 PREPARE org_insert AS INSERT INTO Organization VALUES
     (1, 'headOrg1', NULL),
@@ -44,5 +44,14 @@ SELECT throws_ok (
 SELECT results_eq(
     'SELECT * FROM Organization',
      $$VALUES ( 1, 'headOrg1', NULL), (2, 'headOrg2', NULL), (4, 'Org_1_2', 1)$$
+);
+INSERT INTO Organization VALUES
+    (5, 'Org_1_2_1', 4),
+    (6, 'Org_1_2_1_1', 5),
+    (7, 'Org_1_2_1_1_1', 6),
+    (8, 'Org_1_2_1_1_1_1', 7);
+PREPARE update_head_long_chain AS UPDATE Organization SET head_org_id = 8 WHERE id = 1;
+SELECT throws_ok (
+    'update_head_long_chain'
 );
 ROLLBACK;

--- a/postgres/tests/worker_test.sql
+++ b/postgres/tests/worker_test.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pgtap;
 \set ON_ERROR_ROLLBACK 1
 \set ON_ERROR_STOP true
 BEGIN;
-SELECT plan(17);
+SELECT plan(18);
 
 INSERT INTO Organization VALUES
     (1, 'headOrg1', NULL),
@@ -159,4 +159,7 @@ SELECT results_eq(
     (8, 'Worker_new', 2, 3)$$
 );
 
+PREPARE update_head_id_chain AS UPDATE Worker SET head_id = 5 WHERE id = 3;
+-- 18
+SELECT (throws_ok('update_head_id_chain'));
 ROLLBACK;


### PR DESCRIPTION
#48

Допишу тесты на Worker и с более длинным циклом.

Имеет смысл реализовать проверку в postgres, при помощи триггера на обновление.

Производительность сильно не пострадает от решения в лоб, предполагается, что в реальности такие цепи ростут логарифмически относительно всего набора данных или медленее.

